### PR TITLE
Update to Crystal v0.8 syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.6.1 - September 21, 2015
+
+- Update to Crystal `v0.8.0` syntax/compatibility.
+- Fix a potential use-after-free scenario that may occur when `Context` or `Sandbox` instances were garbage-collected by Crystal.
+- The Duktape heap is no longer destroyed when a `Duktape::InternalError` is thrown in Crystal. Instead, the heap will be destroyed automatically upon finalization.
+
 # v0.6.0 - September 14, 2015
 
 - Update Duktape to `v1.3.0`. This update does not break exisiting functionality. See [release info](https://github.com/svaarala/duktape/blob/master/RELEASES.rst).

--- a/README.md
+++ b/README.md
@@ -6,31 +6,7 @@ Duktape.cr provides Crystal bindings to the [Duktape](https://github.com/svaaral
 
 ## Installation
 
-Duktape.cr is best installed using either [Shards](https://github.com/ysbaddaden/shards) or the Crystal Package Manager.
-
-### Via Crystal Package Manager
-
-Add this to your `Projectfile`:
-
-```crystal
-deps do
-  github "jessedoyle/duktape.cr", name: "duktape"
-end
-```
-
-then execute:
-
-```bash
-crystal deps
-```
-
-Finally build the native Duktape library:
-
-```bash
-make -C libs/duktape/ext libduktape
-```
-
-### Via Shards
+Duktape.cr is best installed using [Shards](https://github.com/ysbaddaden/shards).
 
 Add this to your `shard.yml`:
 
@@ -41,7 +17,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.6.0
+    version: ~> 0.6.1
 ```
 
 then execute:
@@ -50,7 +26,7 @@ then execute:
 shards install
 ```
 
-Note that Shards `v0.4.0` or greater will automatically make the native library. Otherwise you will have to make the library manually by calling `make libduktape` from `libs/duktape/ext`.
+Shards `v0.4.0` or greater will automatically make the native library. You can make the library manually by calling `make libduktape` from `libs/duktape/ext`.
 
 ## Usage
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape.cr
-version: 0.6.0
+version: 0.6.1
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/api/buffer_spec.cr
+++ b/spec/duktape/api/buffer_spec.cr
@@ -10,7 +10,7 @@ describe Duktape::API::Buffer do
       slc = ctx.get_buffer_data -1
 
       ctx.is_external_buffer(-1).should be_true
-      slc.length.should eq(4)
+      slc.size.should eq(4)
     end
 
     it "should raise when not external buffer" do
@@ -42,7 +42,7 @@ describe Duktape::API::Buffer do
       ret = ctx.get_buffer_data -1
 
       ret.should be_a(Slice(UInt8))
-      ret.length.should eq(4)
+      ret.size.should eq(4)
       String.new(ret).should eq("test")
     end
 
@@ -51,14 +51,14 @@ describe Duktape::API::Buffer do
       ctx << "not buffer"
       buf = ctx.get_buffer_data -1
 
-      buf.length.should eq(0)
+      buf.size.should eq(0)
     end
 
     it "should return a 0 size slice on invalid index" do
       ctx = Duktape::Context.new
       buf = ctx.get_buffer_data -1
 
-      buf.length.should eq(0)
+      buf.size.should eq(0)
     end
   end
 
@@ -98,7 +98,7 @@ describe Duktape::API::Buffer do
       ret = ctx.require_buffer_data -1
 
       ret.should be_a(Slice(UInt8))
-      ret.length.should eq(4)
+      ret.size.should eq(4)
       String.new(ret).should eq("test")
     end
 
@@ -147,8 +147,8 @@ describe Duktape::API::Buffer do
       cur = ctx.get_buffer_data -1
 
       buf.should be_a(Slice(UInt8))
-      buf.length.should eq(2)
-      cur.length.should eq(0)
+      buf.size.should eq(2)
+      cur.size.should eq(0)
     end
 
     it "should raise if object is not a dynamic buffer" do

--- a/spec/duktape/api/compile_spec.cr
+++ b/spec/duktape/api/compile_spec.cr
@@ -168,7 +168,7 @@ describe Duktape::API::Compile do
   describe "compile_lstring" do
     it "should compile a valid string with length" do
       ctx = Duktape::Context.new
-      val = ctx.compile_lstring valid_js, valid_js.length
+      val = ctx.compile_lstring valid_js, valid_js.size
 
       ctx.is_function(-1).should be_true
       val.should eq(0)
@@ -176,7 +176,7 @@ describe Duktape::API::Compile do
 
     it "should return non-zero on invalid lstring" do
       ctx = Duktape::Context.new
-      val = ctx.compile_lstring invalid_js, invalid_js.length
+      val = ctx.compile_lstring invalid_js, invalid_js.size
 
       ctx.safe_to_string(-1).should match(/SyntaxError/)
       val.should_not eq(0)
@@ -186,7 +186,7 @@ describe Duktape::API::Compile do
   describe "compile_lstring!" do
     it "should compile a valid string with length" do
       ctx = Duktape::Context.new
-      val = ctx.compile_lstring! valid_js, valid_js.length
+      val = ctx.compile_lstring! valid_js, valid_js.size
 
       ctx.is_function(-1).should be_true
       val.should eq(0)
@@ -196,7 +196,7 @@ describe Duktape::API::Compile do
       ctx = Duktape::Context.new
 
       expect_raises Duktape::Error, /SyntaxError/ do
-        ctx.compile_lstring! invalid_js, invalid_js.length
+        ctx.compile_lstring! invalid_js, invalid_js.size
       end
     end
   end
@@ -206,14 +206,14 @@ describe Duktape::API::Compile do
       ctx = Duktape::Context.new
 
       expect_raises Duktape::StackError, /invalid index/ do
-        ctx.compile_lstring_filename valid_js, valid_js.length
+        ctx.compile_lstring_filename valid_js, valid_js.size
       end
     end
 
     it "should compile a valid js file" do
       ctx = Duktape::Context.new
       ctx << "test.js"
-      err = ctx.compile_lstring_filename valid_js, valid_js.length
+      err = ctx.compile_lstring_filename valid_js, valid_js.size
 
       err.should eq(0)
       ctx.is_function(-1).should be_true
@@ -222,7 +222,7 @@ describe Duktape::API::Compile do
     it "should return non-zero on invalid js" do
       ctx = Duktape::Context.new
       ctx << "test.js"
-      err = ctx.compile_lstring_filename invalid_js, invalid_js.length
+      err = ctx.compile_lstring_filename invalid_js, invalid_js.size
       str = ctx.safe_to_string -1
 
       err.should_not eq(0)
@@ -235,14 +235,14 @@ describe Duktape::API::Compile do
       ctx = Duktape::Context.new
 
       expect_raises Duktape::StackError, /invalid index/ do
-        ctx.compile_lstring_filename! valid_js, valid_js.length
+        ctx.compile_lstring_filename! valid_js, valid_js.size
       end
     end
 
     it "should compile a valid js file" do
       ctx = Duktape::Context.new
       ctx << "test.js"
-      err = ctx.compile_lstring_filename! valid_js, valid_js.length
+      err = ctx.compile_lstring_filename! valid_js, valid_js.size
 
       err.should eq(0)
       ctx.is_function(-1).should be_true
@@ -253,7 +253,7 @@ describe Duktape::API::Compile do
       ctx << "test.js"
 
       expect_raises Duktape::Error, /SyntaxError/ do
-        ctx.compile_lstring_filename! invalid_js, invalid_js.length
+        ctx.compile_lstring_filename! invalid_js, invalid_js.size
       end
     end
   end

--- a/spec/duktape/api/eval_spec.cr
+++ b/spec/duktape/api/eval_spec.cr
@@ -162,7 +162,7 @@ describe Duktape::API::Eval do
   describe "eval_lstring" do
     it "should evaluate a valid js string and length" do
       ctx = Duktape::Context.new
-      err = ctx.eval_lstring valid_js, valid_js.length
+      err = ctx.eval_lstring valid_js, valid_js.size
 
       err.should eq(0)
     end
@@ -178,7 +178,7 @@ describe Duktape::API::Eval do
   describe "eval_lstring!" do
     it "should return 0 on valid js" do
       ctx = Duktape::Context.new
-      err = ctx.eval_lstring! valid_js, valid_js.length
+      err = ctx.eval_lstring! valid_js, valid_js.size
 
       err.should eq(0)
     end
@@ -187,7 +187,7 @@ describe Duktape::API::Eval do
       ctx = Duktape::Context.new
 
       expect_raises Duktape::Error, /ReferenceError/ do
-        ctx.eval_lstring! invalid_js, invalid_js.length
+        ctx.eval_lstring! invalid_js, invalid_js.size
       end
     end
 
@@ -203,7 +203,7 @@ describe Duktape::API::Eval do
   describe "eval_lstring_noresult" do
     it "should evaluate valid js without leaving a stack value" do
       ctx = Duktape::Context.new
-      err = ctx.eval_lstring_noresult valid_js, valid_js.length
+      err = ctx.eval_lstring_noresult valid_js, valid_js.size
 
       err.should eq(0)
       last_stack_type(ctx).should be_js_type(:none)
@@ -211,7 +211,7 @@ describe Duktape::API::Eval do
 
     it "should not leave an error on stack for invalid js" do
       ctx = Duktape::Context.new
-      err = ctx.eval_lstring_noresult invalid_js, invalid_js.length
+      err = ctx.eval_lstring_noresult invalid_js, invalid_js.size
 
       err.should_not eq(0)
       last_stack_type(ctx).should be_js_type(:none)
@@ -228,7 +228,7 @@ describe Duktape::API::Eval do
   describe "eval_lstring_noresult!" do
     it "should return 0 on valid js" do
       ctx = Duktape::Context.new
-      err = ctx.eval_lstring_noresult! valid_js, valid_js.length
+      err = ctx.eval_lstring_noresult! valid_js, valid_js.size
 
       err.should eq(0)
     end
@@ -237,7 +237,7 @@ describe Duktape::API::Eval do
       ctx = Duktape::Context.new
 
       expect_raises Duktape::StackError, /error object missing/ do
-        ctx.eval_lstring_noresult! invalid_js, invalid_js.length
+        ctx.eval_lstring_noresult! invalid_js, invalid_js.size
       end
     end
 

--- a/spec/duktape/api/get_spec.cr
+++ b/spec/duktape/api/get_spec.cr
@@ -28,7 +28,7 @@ describe Duktape::API::Get do
       slc = ctx.get_buffer -1
 
       slc.class.should eq(Slice(UInt8))
-      slc.length.should eq(10)
+      slc.size.should eq(10)
     end
 
     it "should return a null pointer on non-buffer value" do
@@ -120,7 +120,7 @@ describe Duktape::API::Get do
       tup = ctx.get_lstring -1
 
       tup[0].should eq(str)
-      tup[1].should eq(str.length)
+      tup[1].should eq(str.size)
     end
 
     it "should return size of 0 and nil on invalid element" do

--- a/spec/duktape/api/push_spec.cr
+++ b/spec/duktape/api/push_spec.cr
@@ -97,7 +97,7 @@ describe Duktape::API::Push do
       slc = ctx.push_buffer 4, false
 
       slc.class.should eq(Slice(UInt8))
-      slc.length.should eq(4)
+      slc.size.should eq(4)
     end
 
     it "should raise when negative size" do

--- a/spec/duktape/api/require_spec.cr
+++ b/spec/duktape/api/require_spec.cr
@@ -31,7 +31,7 @@ describe Duktape::API::Require do
       buf = ctx.require_buffer(-1)
 
       buf.class.should eq(Slice(UInt8))
-      buf.length.should eq(2)
+      buf.size.should eq(2)
     end
 
     it "should raise TypeError if not a buffer" do
@@ -102,7 +102,7 @@ describe Duktape::API::Require do
       tup = ctx.require_lstring(-1)
 
       tup[0].should eq(str)
-      tup[1].should eq(str.length)
+      tup[1].should eq(str.size)
     end
 
     it "should return a empty string and size of 0" do

--- a/spec/duktape/context_spec.cr
+++ b/spec/duktape/context_spec.cr
@@ -58,6 +58,21 @@ describe Duktape::Context do
     end
   end
 
+  describe "should_gc?" do
+    it "should return true for a newly-created heap" do
+      ctx = Duktape::Context.new
+
+      ctx.should_gc?.should be_true
+    end
+
+    it "should return false when initialized as wrapper obj" do
+      ctx = Duktape::Context.new
+      wrapper = Duktape::Context.new ctx.raw
+
+      wrapper.should_gc?.should be_false
+    end
+  end
+
   describe "sandbox?" do
     it "should return false" do
       ctx = Duktape::Context.new

--- a/spec/duktape/sandbox_spec.cr
+++ b/spec/duktape/sandbox_spec.cr
@@ -62,6 +62,21 @@ describe Duktape::Sandbox do
     end
   end
 
+  describe "should_gc?" do
+    it "should return true for a newly-created heap" do
+      sbx = Duktape::Sandbox.new
+
+      sbx.should_gc?.should be_true
+    end
+
+    it "should return false when initialized as wrapper obj" do
+      sbx = Duktape::Sandbox.new
+      wrapper = Duktape::Sandbox.new sbx.raw
+
+      wrapper.should_gc?.should be_false
+    end
+  end
+
   describe "timeout?" do
     it "should return false when no timeout" do
       sbx = Duktape::Sandbox.new

--- a/src/duktape/api/buffer.cr
+++ b/src/duktape/api/buffer.cr
@@ -12,7 +12,7 @@ module Duktape
         "invalid external buffer"
       end
 
-      LibDUK.config_buffer ctx, index, buf.to_unsafe as Void*, buf.length
+      LibDUK.config_buffer ctx, index, buf.to_unsafe as Void*, buf.size
     end
 
     def get_buffer_data(index : Int32)

--- a/src/duktape/api/push.cr
+++ b/src/duktape/api/push.cr
@@ -10,11 +10,11 @@ module Duktape
       push_boolean value
     end
 
-    def <<(value : SignedInt)
+    def <<(value : Int::Signed)
       push_int value
     end
 
-    def <<(value : UInt8 | UInt16 | UInt32 | UInt64)
+    def <<(value : Int::Unsigned)
       push_uint value
     end
 

--- a/src/duktape/context.cr
+++ b/src/duktape/context.cr
@@ -30,15 +30,17 @@ module Duktape
     def initialize
       @ctx = Duktape.create_heap_default
       @heap_destroyed = false
+      @should_gc = true
     end
 
     def initialize(context : LibDUK::Context)
       @ctx = context
       @heap_destroyed = false
+      @should_gc = false
     end
 
     def finalize
-      destroy_heap!
+      destroy_heap! if should_gc?
     end
 
     def ctx
@@ -63,6 +65,10 @@ module Duktape
       end
 
       @ctx
+    end
+
+    def should_gc?
+      @should_gc
     end
 
     def sandbox?

--- a/src/duktape/error.cr
+++ b/src/duktape/error.cr
@@ -10,20 +10,20 @@ module Duktape
 
     def initialize(ctx : LibDUK::Context, @msg : String, @err : Int32)
       # Capture the stack for later
-      LibDUK.push_context_dump ctx
-      ptr = LibDUK.to_string ctx, -1
-      @stack = String.new ptr
+      # LibDUK.push_context_dump ctx
+      # ptr = LibDUK.to_string ctx, -1
+      # @stack = String.new ptr
 
       Duktape.logger.fatal "InternalError: #{msg} - #{err}"
-      Duktape.logger.debug "STACK: #{stack}"
+      # Duktape.logger.debug "STACK: #{stack}"
 
       # Cleanup
-      LibDUK.destroy_heap ctx
+      # LibDUK.destroy_heap ctx
       super msg
     end
   end
 
-  class HeapError < InternalError
+  class HeapError < Exception
     def initialize(msg : String)
       str = "HeapError: #{msg}"
       Duktape.logger.fatal str

--- a/src/duktape/logger.cr
+++ b/src/duktape/logger.cr
@@ -26,7 +26,7 @@ module Duktape
         unless msg.empty?
           text = msg.split ":"
           io << headerize text.shift, color
-          if text.length > 0
+          if text.size > 0
             io << ":"
             io << text.join ":"
           end

--- a/src/duktape/sandbox.cr
+++ b/src/duktape/sandbox.cr
@@ -13,6 +13,7 @@ module Duktape
       @ctx = Duktape.create_heap_default
       @heap_destroyed = false
       @timeout = nil
+      @should_gc = true
       secure!
     end
 
@@ -20,6 +21,9 @@ module Duktape
       @ctx = context
       @heap_destroyed = false
       @timeout = nil
+      # NOTE: Don't automatically destroy the heap
+      # on finalization when given a `LibDUK::Context`.
+      @should_gc = false
       secure!
     end
 
@@ -34,6 +38,7 @@ module Duktape
       end
       @heap_destroyed = false
       @timeout = timeout
+      @should_gc = true
       secure!
     end
 

--- a/src/duktape/support/time.cr
+++ b/src/duktape/support/time.cr
@@ -17,13 +17,13 @@ module Duktape
     end
 
     def milli_to_sec_time_t(milli : Int32 | Int64)
-      LibC::TimeT.cast milli.to_i64/1000
+      LibC::TimeT.new milli.to_i64/1000
     end
 
     def milli_to_micro_usec_t(milli : Int32 | Int64)
       milli = milli.to_i64
       secs  = milli/1000
-      LibC::UsecT.cast((milli*1000) - (secs*1_000_000))
+      LibC::UsecT.new((milli*1000) - (secs*1_000_000))
     end
 
     def timeout_timeval(timeout : Int64)

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR = 0
     MINOR = 6
-    TINY  = 0
+    TINY  = 1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
- This pull request removes all calls to `length` and replaces them with `size` for compatibility with Crystal `v0.8.0`.
- When initializing a new `Duktape::Context` as such:

``` crystal
ctx_1 = Duktape::Context.new
ctx_2 = Duktape::Context.new ctx_1.raw
```

, the initial Duktape heap for both contexts was destroyed when `ctx_2` was finalized, resulting in a potential use-after-free situation when `ctx_1` was finalized.

The heap is no longer destroyed upon finalization of `ctx_2`, but will be destroyed upon finalization of `ctx_1`.
