### PR TITLE
runtime interface implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,4 @@ language: crystal
 before_install: make libduktape
 script: make spec
 sudo: false
+email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.6.3 - Jan 2, 2016
+
+- Rework the internal require order and `duktape/base`.
+- Add a `Duktape::Runtime` class that lessens the need for low-level API calls for many use-cases. This must be required using `require "duktape/runtime"`.
+
 # v0.6.2 - November 30, 2015
 
 - Update Duktape version to `v1.3.1`. See [release info](https://github.com/svaarala/duktape/blob/master/RELEASES.rst).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.6.2
+    version: ~> 0.6.3
 ```
 
 then execute:
@@ -114,6 +114,39 @@ A `Duktape::Error "RangeError"` exception is raised when the following code exec
 sbx = Duktape::Sandbox.new 500 # 500ms execution time limit
 sbx.eval! "while (true) {}"    # => RangeError
 ```
+
+## Duktape::Runtime
+
+A alternative interface for evaluating JS code is available via the `Duktape::Runtime` class. This class provides a streamlined evaluation API (similar to ExecJS) that allows easier access to javascript values without the need to call many low-level Duktape API functions.
+
+The entire `Runtime` API is as follows:
+
+* `call(property, *args)` - Call the property or function with the given arguments and return the result.
+* `call([properties], *args)` - Call the property that is nested within an array of string property names.
+* `eval(source)` - Evaluate the javascript source and return the last value.
+* `exec(source)` - Evaluate the javascript source and always return `nil`.
+
+`Duktape::Runtime` instances can also be provided an initialization block when created.
+
+Here's an example:
+
+```crystal
+  require "duktape/runtime"
+
+  # A Runtime (optionally) accepts an initialization block
+  rt = Duktape::Runtime.new do |sbx|
+    sbx.eval! <<-JS
+      function test(a, b, c) { return a + b + c; }
+    JS
+  end
+
+  rt.call("test", 3, 4, 5) # => 12 (same as test(3, 4, 5);)
+  rt.call(["Math", "PI"])  # => 3.14159
+  rt.eval("1 + 1")         # => 2
+  rt.exec("1 + 1")         # => nil
+```
+
+Note that `duktape/runtime` is not loaded by the base `duktape` require, and may be used standalone if necessary (ie. replace your `require "duktape"` calls with `require "duktape/runtime"` if you want this functionality).
 
 ## Calling Crystal Code from Javascript
 

--- a/spec/duktape/runtime_spec.cr
+++ b/spec/duktape/runtime_spec.cr
@@ -1,0 +1,150 @@
+require "../spec_helper"
+require "../../src/duktape/runtime"
+
+describe Duktape::Runtime do
+  describe "initialize" do
+    context "without arguments" do
+      it "should create a Runtime instance" do
+        rt = Duktape::Runtime.new
+
+        rt.should be_a(Duktape::Runtime)
+      end
+    end
+
+    context "with a block argument" do
+      it "should pass a Duktape::Sandbox to init JS code with" do
+        rt = Duktape::Runtime.new do |sbx|
+          sbx.should be_a(Duktape::Sandbox)
+          sbx.eval!("function add(num){ return num + num; }")
+        end
+
+        rt.eval("add(9);").should eq(18)
+        rt.should be_a(Duktape::Runtime)
+      end
+    end
+  end
+
+  describe "call" do
+    context "with a single property name" do
+      it "should call the property with the args" do
+        rt = Duktape::Runtime.new do |sbx|
+          sbx.eval!(";function test(num) { return num - 1; }")
+        end
+
+        val = rt.call("test", 123)
+
+        val.should eq(122)
+        val.should be_a(Float64)
+      end
+
+      it "should call a key without arguments" do
+        rt = Duktape::Runtime.new
+        val = rt.call("Math.PI") as Float64
+
+        val.should_not be_nil
+        val.floor.should eq(3)
+      end
+    end
+
+    context "with multiple property names" do
+      it "should call the nested property with arguments" do
+        rt = Duktape::Runtime.new
+        val = rt.call(["JSON", "stringify"], 123) as String
+
+        val.should eq("123")
+      end
+
+      it "should handle multiple arguments" do
+        rt = Duktape::Runtime.new do |sbx|
+          sbx.eval!("function t(a, b, c) { return a + b + c; }")
+        end
+
+        val = rt.call(["t"], 2, 3, 4)
+
+        val.should eq(9)
+        val.should be_a(Float64)
+      end
+
+      it "should return nil for the empty array" do
+        rt = Duktape::Runtime.new
+        val = rt.call([] of String, 123)
+
+        val.should be_nil
+      end
+
+      it "should work without any arguments passed" do
+        rt = Duktape::Runtime.new
+        val = rt.call(["Math", "E"]) as Float64
+
+        val.floor.should eq(2)
+      end
+
+      it "should return a ComplexObject on error" do
+        rt = Duktape::Runtime.new
+        val = rt.call(["JSON", "invalid"], 123) as Duktape::Runtime::ComplexObject
+
+        val.should be_a(Duktape::Runtime::ComplexObject)
+        val.string.should eq("TypeError: not callable")
+      end
+    end
+  end
+
+  describe "eval" do
+    it "should return the last value evaluated" do
+      rt = Duktape::Runtime.new do |sbx|
+        sbx.eval!("; function bool() { return true; }")
+      end
+
+      val = rt.eval("bool();")
+
+      val.should be_true
+      val.should be_a(Bool)
+    end
+
+    it "should return a float evaluated" do
+      rt = Duktape::Runtime.new
+      val = rt.eval("1 + 1;")
+
+      val.should eq(2.0)
+      val.should be_a(Float64)
+    end
+
+    it "should raise a ReferenceError on invalid syntax" do
+      rt = Duktape::Runtime.new
+
+      expect_raises(Duktape::Error, /ReferenceError/) do
+        rt.eval("__abc__;")
+      end
+    end
+  end
+
+  describe "exec" do
+    it "should return nil for all evaluation" do
+      rt = Duktape::Runtime.new
+      val = rt.exec("1 + 1")
+
+      val.should be_nil
+    end
+
+    it "should execute code" do
+      rt = Duktape::Runtime.new do |sbx|
+        sbx.eval!("var a = 1; function add() { a = a + 1; }")
+      end
+
+      val = rt.exec("add();")
+      after = rt.eval("a;")
+
+      val.should be_nil
+      after.should be_a(Float64)
+      after.should eq(2)
+    end
+
+    it "should raise on invalid syntax" do
+      rt = Duktape::Runtime.new
+
+      expect_raises(Duktape::Error, /SyntaxError/) do
+        rt.exec("\"missing")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -4,7 +4,6 @@ ENV["VERIFY"] = "1"
 require "spec"
 require "../src/lib_duktape"
 require "../src/duktape"
-require "../src/duktape/**"
 require "./support/**"
 
 # Disable logging

--- a/src/duktape.cr
+++ b/src/duktape.cr
@@ -4,6 +4,4 @@
 #
 # This is free software. Please see LICENSE for details.
 
-require "./lib_duktape"
-require "./duktape/support/*"
-require "./duktape/*"
+require "./duktape/base"

--- a/src/duktape/base.cr
+++ b/src/duktape/base.cr
@@ -1,0 +1,7 @@
+require "../lib_duktape"
+require "./support/*"
+require "./context"
+require "./error"
+require "./logger"
+require "./sandbox"
+require "./version"

--- a/src/duktape/runtime.cr
+++ b/src/duktape/runtime.cr
@@ -1,0 +1,219 @@
+# runtime.cr: simplified Duktape call/eval interface
+#
+# Copyright (c) 2016 Jesse Doyle. All rights reserved.
+#
+# This is free software. Please see LICENSE for details.
+
+require "./base"
+
+module Duktape
+  # A Runtime is a simplified mechanism for evaluating javascript code
+  # without directly using the low-level Duktape API calls.
+  #
+  # Instances of the Runtime class may evaluate code using an interface
+  # inspired by (ExecJS)[https://github.com/rails/execjs]. The method calls
+  # within this class all return the last evaluated value (with the exception
+  # of `exec`).
+  #
+  # ```
+  # rt = Duktape::Runtime.new
+  # rt.eval("Math.PI") #=> 3.14159
+  # ```
+  #
+  # The Runtime class also allows for javascript initialization code:
+  #
+  # ```
+  # rt = Duktape::Runtime.new do |ctx|
+  #   ctx.eval! <<-JS
+  #     function add_one(num){ return num + 1; }
+  #   JS
+  # end
+  #
+  # rt.eval("add_one", 42) #=> 43
+  # ```
+  #
+  # The Runtime class is not loaded by default and must be required before
+  # using it:
+  #
+  # ```
+  # require "duktape/runtime"
+  # ```
+  #
+  # Also note that the Runtime class includes the base Duktape code for you
+  # and may be used in a standalone manner.
+  #
+  class Runtime
+    # Code evaluating using a `Duktape::Runtime` instance will return a value
+    # that depends on the last evaluated javascript expression.
+    #
+    # Some javascript objects are too complex to be mapped to Crystal values.
+    # A `ComplexObject` instance is returned from evaluation calls when this
+    # is the case.
+    #
+    # Currently, the primitive types such as Booleans, Numbers, Strings and
+    # undefined/null are mapped directly to Crystal values.
+    #
+    # Any other javascript return type will be returned as an instance of
+    # `ComplexObject`.
+    #
+    class ComplexObject
+      getter kind, string
+
+      def initialize(@kind : Symbol, @string : String)
+      end
+
+      def to_s
+        "<Duktape::ComplexObject::#{kind.to_s.capitalize}>: #{string}"
+      end
+    end
+
+    def initialize
+      @context = Duktape::Sandbox.new
+    end
+
+    def initialize(&block)
+      @context = Duktape::Sandbox.new
+      yield @context
+      # Remove all values from the stack left
+      # over from initialization code
+      @context.set_top(0) if @context.get_top > 0
+    end
+
+    # Call the named property with the supplied arguments,
+    # returning the value of the called property.
+    #
+    # The property string can include parent objects:
+    #
+    # ```
+    #  rt = Duktape::Runtime.new
+    #  rt.call("JSON.stringify", 123) #=> "123"
+    # ```
+    #
+    def call(prop : String, *args)
+      call prop.split("."), *args
+    end
+
+    # Call the nested property that is supplied via an
+    # array of strings with the supplied arguments.
+    #
+    # ```
+    #  rt = Duktape::Runtime.new
+    #  rt.call(["Math", "PI"]) #=> 3.14159
+    # ```
+    #
+    def call(props : Array(String), *args)
+      return nil if props.empty?
+
+      prepare_nested_prop props
+      if args.size > 0
+        push_args args
+        # We want a reference to the last property that was
+        # successfully accessed via `get_prop`. Because we
+        # leave the last property name in the chain as a string
+        # , this should only depend on the number of arguments
+        # on the stack.
+        obj_idx = -(args.size + 2)
+        @context.call_prop obj_idx, args.size
+      else
+        @context.get_prop -2
+      end
+
+      stack_to_crystal(-1).tap do
+        @context.pop_2
+      end
+    end
+
+    # Evaluate the supplied source code on the underlying javascript
+    # context and return the last value:
+    #
+    # ```
+    # rt = Duktape::Runtime.new
+    # rt.eval("1 + 1") => 2.0
+    # ```
+    #
+    def eval(source : String)
+      @context.eval! source
+      stack_to_crystal -1
+    end
+
+    # Execute the supplied source code on the underyling javascript
+    # context without returning any value.
+    #
+    # ```
+    # rt = Duktape::Runtime.new
+    # rt.exec("1 + 1") #=> nil
+    # ```
+    #
+    def exec(source : String)
+      @context.eval! source
+      @context.pop
+      nil
+    end
+
+    # :nodoc:
+    private def stack_to_crystal(index : Int32)
+      case @context.get_type(index)
+      when :none
+        nil
+      when :undefined
+        nil
+      when :null
+        nil
+      when :boolean
+        @context.get_boolean index
+      when :number
+        @context.get_number index
+      when :string
+        @context.get_string index
+      when :object
+        ComplexObject.new :object, object_to_string(index)
+      when :buffer
+        ComplexObject.new :buffer, object_to_string(index)
+      when :pointer
+        ComplexObject.new :pointer, object_to_string(index)
+      when :lightfunc
+        ComplexObject.new :lightfunc, object_to_string(index)
+      else
+        raise TypeError.new "invalid type at index #{index}"
+      end
+    end
+
+    # :nodoc:
+    private def object_to_string(index : Int32)
+      @context.safe_to_string(-1).tap do
+        @context.pop
+      end
+    end
+
+    # :nodoc:
+    private def prepare_nested_prop(props : Array(String))
+      @context.push_global_object
+      props.each_with_index do |prop, count|
+        @context << prop
+        # Break after pushing the last property name
+        # so that we are able to use `call_prop` method
+        # on the last property name as a string.
+        break if count == props.size - 1
+        @context.get_prop(-2).tap do |found|
+          unless found
+            raise Error.new "invalid property: #{prop}"
+          end
+        end
+      end
+    end
+
+    # :nodoc:
+    private def push_args(args)
+      args.each do |arg|
+        case arg
+        when Int::Signed, Int::Unsigned, Bool, String, Float
+          @context << arg
+        when Symbol
+          @context.push_string arg.to_s
+        else
+          raise TypeError.new "unable to convert to JS type"
+        end
+      end
+    end
+  end
+end

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR = 0
     MINOR = 6
-    TINY  = 2
+    TINY  = 3
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."

--- a/src/ext/Makefile
+++ b/src/ext/Makefile
@@ -67,7 +67,7 @@ CFLAGS = \
 libduktape: $(OUTPUT)/libduktape.o $(LIBDIR)/libduktape.a $(INCLUDEDIR)/duktape.h
 $(OUTPUT)/libduktape.o: $(EXT)/duktape.c
 	@mkdir -p $(OUTPUT)
-	gcc -o $@ $(EXT)/duktape.c $(CFLAGS) $(DUK_OPTS)
+	$(CC) -o $@ $(EXT)/duktape.c $(CFLAGS) $(DUK_OPTS)
 $(LIBDIR)/libduktape.a:
 	@mkdir -p $(LIBDIR)
 	ar rcs $(LIBDIR)/libduktape.a $(OUTPUT)/libduktape.o


### PR DESCRIPTION
After working with the Duktape API calls for some time, I've noticed that many use-cases don't require the low-level usage of many Duktape calls.

This pull request implements a higher level `Duktape::Runtime` class that takes inspiration from the `ExecJS` API.

The entire Runtime API is as follows:
- `call(property, *args)` - Call the property or function with the given arguments and return the result.
- `call([properties], *args)` - Call the property that is nested within an array of string property names.
- `eval(source)` - Evaluate the javascript source and return the last value.
- `exec(source)` - Evaluate the javascript source and always return nil.

I expect this Travis build to fail as the bug that is causing the failure was just fixed in Crystal master.
