### PR TITLE
Duktape::Runtime call now accepts hashes and arrays as arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Not yet released
+
+- `Duktape::Runtime` can now accept hashes and arrays as arguments for call. These will be translated into Javascript objects and pushed to the stack.
+- Added the bugfix from Crystal [#1982](https://github.com/manastech/crystal/issues/1982) to make specs work again. This is a temporary monkey patch and will be removed once a new version of Crystal is released.
+
 # v0.6.4 - Jan 2, 2016
 
 - Add the `src/runtime.cr` file so you can now properly `require "./duktape/runtime"` once `shards` does its thing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Not yet released
+# Master
 
 - `Duktape::Runtime` can now accept hashes and arrays as arguments for call. These will be translated into Javascript objects and pushed to the stack.
 - Added the bugfix from Crystal [#1982](https://github.com/manastech/crystal/issues/1982) to make specs work again. This is a temporary monkey patch and will be removed once a new version of Crystal is released.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape.cr
-version: 0.6.4
+version: 0.6.5
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/runtime_spec.cr
+++ b/spec/duktape/runtime_spec.cr
@@ -4,7 +4,9 @@ require "../../src/duktape/runtime"
 # We need access to the raw context to test some things
 module Duktape
   class Runtime
-    def ctx; @context end
+    def ctx
+      @context
+    end
   end
 end
 
@@ -97,7 +99,7 @@ describe Duktape::Runtime do
 
     it "should accept hashes as arguments" do
       rt = Duktape::Runtime.new
-      val = rt.call("JSON.stringify", { a: "test", b: 123 })
+      val = rt.call("JSON.stringify", {a: "test", b: 123})
 
       val.should be_a(String)
       val.should eq("{\"a\":\"test\",\"b\":123}")
@@ -105,7 +107,7 @@ describe Duktape::Runtime do
 
     it "should accept nested hashes and arrays as arguments" do
       rt = Duktape::Runtime.new
-      val = rt.call("JSON.stringify", { a: [1, 2, { three: "four" }]})
+      val = rt.call("JSON.stringify", {a: [1, 2, {three: "four"}]})
 
       val.should be_a(String)
       val.should eq("{\"a\":[1,2,{\"three\":\"four\"}]}")
@@ -133,7 +135,7 @@ describe Duktape::Runtime do
 
       it "should have an empty stack after the call" do
         rt = Duktape::Runtime.new
-        val = rt.call("JSON.stringify", { a: true, b: -10 })
+        val = rt.call("JSON.stringify", {a: true, b: -10})
 
         val.should be_a(String)
         val.should eq("{\"a\":true,\"b\":-10}")

--- a/spec/duktape/runtime_spec.cr
+++ b/spec/duktape/runtime_spec.cr
@@ -1,6 +1,13 @@
 require "../spec_helper"
 require "../../src/duktape/runtime"
 
+# We need access to the raw context to test some things
+module Duktape
+  class Runtime
+    def ctx; @context end
+  end
+end
+
 describe Duktape::Runtime do
   describe "initialize" do
     context "without arguments" do
@@ -20,11 +27,90 @@ describe Duktape::Runtime do
 
         rt.eval("add(9);").should eq(18)
         rt.should be_a(Duktape::Runtime)
+        rt.ctx.get_top.should eq(0)
       end
     end
   end
 
   describe "call" do
+    it "should accept signed ints as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("Math.sqrt", 9_i32)
+
+      val.should eq(3)
+    end
+
+    it "should accept unsigned ints as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("Math.sqrt", 9_u32)
+
+      val.should eq(3)
+    end
+
+    it "should accept booleans as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("Boolean", false)
+
+      val.should eq(false)
+      val.should be_a(Bool)
+    end
+
+    it "should accept strings as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("parseInt", "10")
+
+      val.should eq(10)
+    end
+
+    it "should call to_s on symbol arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("JSON.stringify", :some_text)
+
+      val.should eq("\"some_text\"")
+    end
+
+    it "should accept floats as arguments" do
+      rt = Duktape::Runtime.new do |sbx|
+        sbx.eval!("function add(a, b) { return a + b; }")
+      end
+      val = rt.call("add", 3.14159_f32, -16_f64) as Float64
+
+      val.should be_a(Float64)
+      val.to_s.should eq("-12.8584")
+    end
+
+    it "should accept arrays as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call(["JSON", "stringify"], [true, 1, "test", :sym])
+
+      val.should be_a(String)
+      val.should eq("[true,1,\"test\",\"sym\"]")
+    end
+
+    it "should accept nested arrays as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call(["JSON", "stringify"], [1, [2, [3, 4]]])
+
+      val.should be_a(String)
+      val.should eq("[1,[2,[3,4]]]")
+    end
+
+    it "should accept hashes as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("JSON.stringify", { a: "test", b: 123 })
+
+      val.should be_a(String)
+      val.should eq("{\"a\":\"test\",\"b\":123}")
+    end
+
+    it "should accept nested hashes and arrays as arguments" do
+      rt = Duktape::Runtime.new
+      val = rt.call("JSON.stringify", { a: [1, 2, { three: "four" }]})
+
+      val.should be_a(String)
+      val.should eq("{\"a\":[1,2,{\"three\":\"four\"}]}")
+    end
+
     context "with a single property name" do
       it "should call the property with the args" do
         rt = Duktape::Runtime.new do |sbx|
@@ -43,6 +129,15 @@ describe Duktape::Runtime do
 
         val.should_not be_nil
         val.floor.should eq(3)
+      end
+
+      it "should have an empty stack after the call" do
+        rt = Duktape::Runtime.new
+        val = rt.call("JSON.stringify", { a: true, b: -10 })
+
+        val.should be_a(String)
+        val.should eq("{\"a\":true,\"b\":-10}")
+        rt.ctx.get_top.should eq(0)
       end
     end
 
@@ -86,6 +181,14 @@ describe Duktape::Runtime do
         val.should be_a(Duktape::Runtime::ComplexObject)
         val.string.should eq("TypeError: not callable")
       end
+
+      it "should have an empty stack after the call" do
+        rt = Duktape::Runtime.new
+        val = rt.call(["Math", "sqrt"], 9)
+
+        val.should eq(3)
+        rt.ctx.get_top.should eq(0)
+      end
     end
   end
 
@@ -116,6 +219,13 @@ describe Duktape::Runtime do
         rt.eval("__abc__;")
       end
     end
+
+    it "should have an empty stack after evaluation" do
+      rt = Duktape::Runtime.new
+      rt.eval("2 + 2;")
+
+      rt.ctx.get_top.should eq(0)
+    end
   end
 
   describe "exec" do
@@ -145,6 +255,13 @@ describe Duktape::Runtime do
       expect_raises(Duktape::Error, /SyntaxError/) do
         rt.exec("\"missing")
       end
+    end
+
+    it "should have an empty stack after execution" do
+      rt = Duktape::Runtime.new
+      rt.exec("2 + 2;")
+
+      rt.ctx.get_top.should eq(0)
     end
   end
 end

--- a/src/duktape/logger.cr
+++ b/src/duktape/logger.cr
@@ -7,6 +7,63 @@
 require "colorize"
 require "logger"
 
+# FIXME: Crystal 0.10.0 core has a bug that closes the
+# logger IO (STDOUT) at exit. This makes the spec
+# suite crash. See this:
+# https://github.com/manastech/crystal/issues/1982.
+#
+# This is a temporary monkey patch until a new version
+# has been released.
+class Logger(T)
+  def initialize(@io : T)
+    @level = Severity::INFO
+    @formatter = DEFAULT_FORMATTER
+    @progname = ""
+    @channel = Channel(Message).new(100)
+    @close_channel = Channel(Nil).new
+    @closed = false
+    @shutdown = false
+    spawn write_messages
+    at_exit { shutdown }
+  end
+
+  def close
+    return if @closed
+    @closed = true
+    shutdown
+  end
+
+  private def write_messages
+    loop do
+      msg = Channel.receive_first(@channel, @close_channel)
+      if msg.is_a?(Message)
+        label = msg.severity == Severity::UNKNOWN ? "ANY" : msg.severity.to_s
+
+        # We write to an intermediate String because the IO might be sync'ed so
+        # we avoid some system calls. In the future we might want to add an IO#sync?
+        # method to every IO so we can do this conditionally.
+        @io << String.build do |str|
+          formatter.call(label, msg.datetime, msg.progname.to_s, msg.message.to_s, str)
+          str.puts
+        end
+
+        @io.flush
+      else
+        @io.close if @closed
+        @close_channel.send(nil)
+        break
+      end
+    end
+  end
+
+  private def shutdown
+    return if @shutdown
+    @shutdown = true
+    @close_channel.send(nil)
+    @close_channel.receive
+  end
+end
+
 module Duktape
   def self.logger
     @@log ||= make_logger

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR = 0
     MINOR = 6
-    TINY  = 4
+    TINY  = 5
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
This PR allows the `call` method to accept both hashes and arrays which are then translated to Javascript objects or arrays:

``` crystal
rt = Duktape::Runtime.new
rt.call("JSON.stringify", {a: [1, 2, {three: "four"}]}) # => "{\"a\":[1,2,{\"three\":\"four\"}]}"
```

I've also monkey patched the Crystal logger in this PR to make the test suite build properly again due to a bug that was fixed in Crystal core. This will be removed once a new version of Crystal is released.
