### PR TITLE
update changelog and start on 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
+# Master (v0.7.1.pre)
+
+- `Duktape::Runtime` instances may now accept a execution timeout value in milliseconds upon creation. [[#15](https://github.com/jessedoyle/duktape.cr/pull/15), [@raydf](https://github.com/raydf)].
+
 # v0.7.0 - Jan 18, 2016
+
 - (_breaking change_) A monkeypatch to the Crystal `Logger` class was temporarily added to master to fix a bug in core Crystal ([#1982](https://github.com/manastech/crystal/issues/1982)). This patch has now been removed from the codebase. Crystal `v0.10.1` or higher is a requirement for this library.
 - `Duktape::Runtime` instances now return Crystal arrays and hashes for corresponding JS arrays and objects.
 - `Duktape::Runtime` can now accept hashes and arrays as arguments for call. These will be translated into Javascript objects and pushed to the stack.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape.cr
-version: 0.7.0
+version: 0.7.1.pre
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/duktape_spec.cr
+++ b/spec/duktape/duktape_spec.cr
@@ -1,6 +1,18 @@
 require "../spec_helper"
 
 describe Duktape do
+  describe "self.version" do
+    it "should not have an empty version string" do
+      Duktape.version.should_not eq("")
+    end
+  end
+
+  describe "self.api_version" do
+    it "should not have an empty version string" do
+      Duktape.api_version.should_not eq("")
+    end
+  end
+
   describe "self.create_heap_default" do
     it "should allocate a LibDUK::Context" do
       ctx = Duktape.create_heap_default

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,8 +16,8 @@ module Duktape
   module VERSION
     MAJOR = 0
     MINOR = 7
-    TINY  = 0
-    PRE   = nil
+    TINY  = 1
+    PRE   = "pre"
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."
 


### PR DESCRIPTION
- Added basic specs to ensure that version strings are not empty.
- Updated changelog for #15.
- Set version to `0.7.1.pre`
