### PR TITLE
Add push_global_proc method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Master (v0.7.1.pre)
 
+- Added `call_success`, `call_failure` and `return_undefined` convenience methods that provide the appropriate integer status codes when returning from a native function call.
+- Added the `push_global_proc` method that simplifies pushing a named native function to the stack.
 - `Duktape::Runtime` instances may now accept a execution timeout value in milliseconds upon creation. [[#15](https://github.com/jessedoyle/duktape.cr/pull/15), [@raydf](https://github.com/raydf)].
 
 # v0.7.0 - Jan 18, 2016

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Note that `duktape/runtime` is not loaded by the base `duktape` require, and may
 
 ## Calling Crystal Code from Javascript
 
-Note: This functionality is considered experimental and syntax/functionality may change dramatically between releases.
+**Note**: This functionality is considered experimental and syntax/functionality may change dramatically between releases.
 
 It is possible to call Crystal code from your javascript:
 
@@ -178,9 +178,9 @@ It is possible to call Crystal code from your javascript:
   sbx.eval! "print(add_together(2, 3));" # => 5
 ```
 
-The `proc` object that is pushed to the Duktape stack accepts a pointer to `Context` instance, we must wrap this pointer by calling `env = Duktape::Sandbox.new ptr`. The `proc` must also return an `Int32` status code - `env.call_failure` and `env.call_success` will provide the proper integer values.
+The `proc` object that is pushed to the Duktape stack accepts a pointer to a `Context` instance. We must wrap this pointer by calling `env = Duktape::Sandbox.new ptr`. The `proc` must also return an `Int32` status code - `env.call_failure` and `env.call_success` will provide the proper integer values.
 
-Note: Because it is currently not possible to pass closures to C bindings in Crystal, one must be careful that any variables used in the `proc` must not be referenced or initialized outside the `proc`'s scope. This is why variable names such as `env` are used.
+**Note**: Because it is currently not possible to pass closures to C bindings in Crystal, one must be careful that any variables used in the `proc` must not be referenced or initialized outside the scope of the `proc`. This is why variable names such as `env` are used.
 
 ## Contributing
 

--- a/spec/duktape/api/call_spec.cr
+++ b/spec/duktape/api/call_spec.cr
@@ -37,6 +37,27 @@ describe Duktape::API::Call do
     end
   end
 
+  describe "call_failure" do
+    Duktape::API::Call::ERRORS.keys.each do |err|
+      it "#{err}: should return a negative status code" do
+        ctx = Duktape::Context.new
+        num = ctx.call_failure err
+
+        (num < 0).should be_true
+        num.should eq(Duktape::API::Call::ERRORS[err])
+        num.should be_a(Int32)
+      end
+    end
+
+    it "should raise Duktape::Error if error does not exist" do
+      ctx = Duktape::Context.new
+
+      expect_raises(Duktape::Error, /invalid error type/) do
+        ctx.call_failure :invalid
+      end
+    end
+  end
+
   describe "call_method" do
     it "should call a method from stack" do
       ctx = Duktape::Context.new
@@ -93,6 +114,16 @@ describe Duktape::API::Call do
     end
   end
 
+  describe "call_success" do
+    it "should return 1 as an Int32" do
+      ctx = Duktape::Context.new
+      num = ctx.call_success
+
+      num.should be_a(Int32)
+      num.should eq(1)
+    end
+  end
+
   describe "new" do
     it "should call the constructor" do
       # JS: new String("test string");
@@ -121,6 +152,16 @@ describe Duktape::API::Call do
       num = ctx.return 42
 
       num.should eq(42)
+    end
+  end
+
+  describe "return_undefined" do
+    it "should return an Int32 of 0" do
+      ctx = Duktape::Context.new
+      num = ctx.return_undefined
+
+      num.should be_a(Int32)
+      num.should eq(0)
     end
   end
 end

--- a/spec/support/proc_helper.cr
+++ b/spec/support/proc_helper.cr
@@ -1,0 +1,17 @@
+# We need to use a macro to generate code here
+# to avoid Crystal thinking that we are passing
+# a closure to a c binding.
+# Note: This assumes `ctx` is already a valid Duktape::Context
+macro proc_should_return_error(error)
+  it "should push {{error.id}} error to the stack when called" do
+    ctx.push_proc do |ptr|
+      env = Duktape::Context.new ptr
+      env.call_failure {{error}}
+    end
+
+    ctx.call 0
+
+    ctx.is_error(-1).should be_true
+    ctx.safe_to_string(-1).should match(/{{error.id}}/)
+  end
+end

--- a/src/duktape/api/call.cr
+++ b/src/duktape/api/call.cr
@@ -9,10 +9,33 @@ module Duktape
   # `pcall_xxx` functions because we wish to safely return
   # from errors.
   module API::Call
+    ERRORS = {
+      unimplemented: -LibDUK::ERR_UNIMPLEMENTED_ERROR,
+      unsupported:   -LibDUK::ERR_UNSUPPORTED_ERROR,
+      internal:      -LibDUK::ERR_INTERNAL_ERROR,
+      alloc:         -LibDUK::ERR_ALLOC_ERROR,
+      assertion:     -LibDUK::ERR_ASSERTION_ERROR,
+      api:           -LibDUK::ERR_API_ERROR,
+      uncaught:      -LibDUK::ERR_UNCAUGHT_ERROR,
+      error:         -LibDUK::ERR_ERROR,
+      eval:          -LibDUK::ERR_EVAL_ERROR,
+      range:         -LibDUK::ERR_RANGE_ERROR,
+      reference:     -LibDUK::ERR_REFERENCE_ERROR,
+      syntax:        -LibDUK::ERR_SYNTAX_ERROR,
+      type:          -LibDUK::ERR_TYPE_ERROR,
+      uri:           -LibDUK::ERR_URI_ERROR,
+    }
+
     def call(nargs : Int32)
       require_valid_nargs nargs
       require_valid_index -(nargs + 1) # function and args
       LibDUK.pcall(ctx, nargs) == 0
+    end
+
+    def call_failure(value = :error)
+      ERRORS[value]
+    rescue KeyError
+      raise Error.new "invalid error type: #{value}"
     end
 
     def call_method(nargs : Int32)
@@ -27,6 +50,10 @@ module Duktape
       LibDUK.pcall_prop(ctx, index, nargs) == 0
     end
 
+    def call_success
+      1
+    end
+
     # Equivalent to duk_pnew (protected call)
     def new(nargs : Int32)
       require_valid_nargs nargs
@@ -35,6 +62,10 @@ module Duktape
 
     def return(ret_val : Int32)
       ret_val
+    end
+
+    def return_undefined
+      0
     end
 
     # Experimental

--- a/src/duktape/api/push.cr
+++ b/src/duktape/api/push.cr
@@ -87,6 +87,14 @@ module Duktape
       LibDUK.push_global_object ctx
     end
 
+    # Experimental
+    def push_global_proc(name : String, nargs = 0 : Int32, &block : LibDUK::Context -> Int32)
+      push_global_object
+      push_proc nargs, &block
+      put_prop_string -2, name
+      pop
+    end
+
     def push_global_stash
       LibDUK.push_global_stash ctx
     end

--- a/src/duktape/runtime.cr
+++ b/src/duktape/runtime.cr
@@ -70,7 +70,7 @@ module Duktape
       # over from initialization code
       reset_stack!
     end
-    
+
     def initialize(timeout : Int32 | Int64)
       @context = Duktape::Sandbox.new timeout
     end


### PR DESCRIPTION
This PR simplifies the process to push a named native function to the Duktape stack:

``` crystal
sbx.push_global_proc("test", 0) do |ptr|
  env = Duktape::Sandbox.new ptr
  env << 42
  env.call_success 
end

sbx.eval!("test();") # => 42
```

This PR also adds the `env.call_success`, `env.call_failure` and `env.return_undefined` helpers to return the proper integer status codes from a native call.

Note: `call_failure` may optionally take a symbol that will define the type of error object pushed to the stack after a call.

Here's the current possible symbols:

``` crystal
    ERRORS = {
      unimplemented: -LibDUK::ERR_UNIMPLEMENTED_ERROR,
      unsupported:   -LibDUK::ERR_UNSUPPORTED_ERROR,
      internal:      -LibDUK::ERR_INTERNAL_ERROR,
      alloc:         -LibDUK::ERR_ALLOC_ERROR,
      assertion:     -LibDUK::ERR_ASSERTION_ERROR,
      api:           -LibDUK::ERR_API_ERROR,
      uncaught:      -LibDUK::ERR_UNCAUGHT_ERROR,
      error:         -LibDUK::ERR_ERROR,
      eval:          -LibDUK::ERR_EVAL_ERROR,
      range:         -LibDUK::ERR_RANGE_ERROR,
      reference:     -LibDUK::ERR_REFERENCE_ERROR,
      syntax:        -LibDUK::ERR_SYNTAX_ERROR,
      type:          -LibDUK::ERR_TYPE_ERROR,
      uri:           -LibDUK::ERR_URI_ERROR,
    }
```

So for example:

``` crystal
sbx.push_proc do |ptr|
  ...
  env.call_failure(:reference) # => causes a ReferenceError to be pushed to stack after the call
  ...
end
```
