### PR TITLE
Prepare For Crystal > 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.8.2 - May 5, 2016
+
+- Update to Crystal `0.16.0` syntax.
+
 # v0.8.1 - Mar 23, 2016
 
 - Update to Crystal `0.14.2` syntax.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.8.1
+    version: ~> 0.8.2
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.8.1
+version: 0.8.2
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/utils/time_spec.cr
+++ b/spec/duktape/utils/time_spec.cr
@@ -4,12 +4,12 @@ describe Duktape::Support::Time do
   time = TimeMock.new
 
   describe "current_time_nano" do
-    it "should return a TimeVal containing current time" do
+    it "should return a Timeval containing current time" do
       tv = time.current_time_nano
 
-      tv.should be_a(LibC::TimeVal)
+      tv.should be_a(LibC::Timeval)
       tv.tv_sec.should be_a(LibC::TimeT)
-      tv.tv_usec.should be_a(LibC::UsecT)
+      tv.tv_usec.should be_a(LibC::SusecondsT)
     end
   end
 
@@ -24,21 +24,21 @@ describe Duktape::Support::Time do
   end
 
   describe "milli_to_micro_usec_t" do
-    it "should convert milliseconds to microseconds as UsecT (subtracting seconds)" do
+    it "should convert milliseconds to microseconds as SusecondsT (subtracting seconds)" do
       milli = 17123
       usecs = time.milli_to_micro_usec_t milli
 
-      usecs.should be_a(LibC::UsecT)
+      usecs.should be_a(LibC::SusecondsT)
       usecs.should eq(123000)
     end
   end
 
   describe "timeout_timeval" do
-    it "should create a TimeVal for timeout specified" do
+    it "should create a Timeval for timeout specified" do
       timeout = 3732_i64
       tv = time.timeout_timeval timeout
 
-      tv.should be_a(LibC::TimeVal)
+      tv.should be_a(LibC::Timeval)
       tv.tv_sec.should eq(3)
       tv.tv_usec.should eq(732000)
     end

--- a/src/duktape/api/compile.cr
+++ b/src/duktape/api/compile.cr
@@ -23,7 +23,7 @@ module Duktape
       raise_error err
     end
 
-    def compile!(str : String, flags =  0_u32)
+    def compile!(str : String, flags = 0_u32)
       compile_string! str, flags
     end
 

--- a/src/duktape/error.cr
+++ b/src/duktape/error.cr
@@ -6,6 +6,9 @@
 
 module Duktape
   class InternalError < Exception
+    @ctx : Void*?
+    @stack : String?
+
     getter msg, err
 
     def initialize(@msg : String)

--- a/src/duktape/logger.cr
+++ b/src/duktape/logger.cr
@@ -8,6 +8,8 @@ require "colorize"
 require "logger"
 
 module Duktape
+  @@log : Logger?
+
   def self.logger
     @@log ||= make_logger
   end

--- a/src/duktape/support/time.cr
+++ b/src/duktape/support/time.cr
@@ -22,13 +22,13 @@ module Duktape
     def milli_to_micro_usec_t(milli : Int32 | Int64)
       milli = milli.to_i64
       secs = milli / 1000
-      LibC::UsecT.new((milli * 1000) - (secs * 1_000_000))
+      LibC::SusecondsT.new((milli * 1000) - (secs * 1_000_000))
     end
 
     def timeout_timeval(timeout : Int64)
       sec = milli_to_sec_time_t timeout
       usec = milli_to_micro_usec_t timeout
-      LibC::TimeVal.new tv_sec: sec, tv_usec: usec
+      LibC::Timeval.new tv_sec: sec, tv_usec: usec
     end
   end
 end

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR = 0
     MINOR = 8
-    TINY  = 1
+    TINY  = 2
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."

--- a/src/lib_duktape.cr
+++ b/src/lib_duktape.cr
@@ -113,8 +113,8 @@ lib LibDUK
   VARARGS = -1_i32
 
   struct TimeoutData
-    start : LibC::TimeVal
-    timeout : LibC::TimeVal
+    start : LibC::Timeval
+    timeout : LibC::Timeval
   end
 
   struct MemoryFunctions


### PR DESCRIPTION
- Crystal > 0.15 will have a new type inference algorithm that
  requires explicit type definition for instance and class variables.
- Add the necessary type annotations for the new type inference
  algorithm and preapre 0.8.2 for release.

See: [#2443](https://github.com/crystal-lang/crystal/pull/2443)
