### PR TITLE
Fix Type Restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v0.10.1 - Jan 31, 2017
+
+- Fix an incorrect type restriction that was causing
+  compiler issues on recent Crystal versions.
+- Fix Sandbox timeout tests by no longer running
+  a set number of iterations - instead infinite loop
+  until timeout.
+
 # v0.10.0 - Nov 22, 2016
 
 - Update for Crystal 0.20.0. As shards now copies

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.10.0
+    version: ~> 0.10.1
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.10.0
+version: 0.10.1
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/sandbox_spec.cr
+++ b/spec/duktape/sandbox_spec.cr
@@ -108,13 +108,10 @@ describe Duktape::Sandbox do
 
   context "timeout during evaluation" do
     it "should raise a Duktape::RangeError on timeout" do
-      sbx = Duktape::Sandbox.new(500)
+      sbx = Duktape::Sandbox.new(100)
       expect_raises Duktape::RangeError, /execution timeout/ do
         sbx.eval! <<-JS
-          var times = 1000000;
-          for(var i = 0; i < times; i++){
-            i * i;
-          }
+          while (true) {}
         JS
       end
     end

--- a/src/duktape/api/compile.cr
+++ b/src/duktape/api/compile.cr
@@ -14,7 +14,7 @@ module Duktape
       LibDUK.compile_raw ctx, nil, 0, (flags | LibDUK::COMPILE_SAFE)
     end
 
-    def compile(str : String, flags : UInt32 = 0)
+    def compile(str : String, flags : UInt32 = 0_u32)
       compile_string str, flags
     end
 

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR = 0
     MINOR = 10
-    TINY  = 0
+    TINY  = 1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
* Fix an incorrect type restriction my setting a default value
  of a UInt32 (instead of Int32).
* No longer test sandbox timeouts using a set number of iterations,
  instead create an infinate loop that will have to time out.
* Release version 0.10.1.