### PR TITLE
Fix Liguist Vendor Path

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-src/ext/* linguist-vendored
+ext/* linguist-vendored
 spec/javascripts/* linguist-vendored


### PR DESCRIPTION
* Add the `ext` directory as a linguist vendored path so that
  GitHub properly recognizes this repo as a Crystal project.

NOTE: As this commit is only a change in repository metadata, no new version will be released.