### PR TITLE
[HEAP] - create_heap_default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.12.1 - Nov 2, 2017
+
+- [_bugfix_] - Fix an unintended `Duktape` heap instantiation when creating a new `Duktape::Context`.
+- Run `crystal tool format` on all source code.
+
 # v0.12.0 - Oct 2017
 
 - [**breaking change**] All `LibDUK` hardcoded types are now `enum` values (i.e. `LibDUK::TYPE_NULL` becomes `LibDUK::Type::Null`). Where possible, methods accept both the original types as well as enumerated values.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.12.0
+    version: ~> 0.12.1
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.12.0
+version: 0.12.1
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/api/thread_spec.cr
+++ b/spec/duktape/api/thread_spec.cr
@@ -5,7 +5,7 @@ describe Duktape::API::Thread do
     it "suspends Duktape execution" do
       ctx = Duktape::Context.new
       ctx.push_global_proc("test") do |ptr|
-      env = Duktape::Context.new ptr
+        env = Duktape::Context.new ptr
         state = env.suspend
         # as the engine is suspended, we should not evaluate 'true'
         env.eval("true")
@@ -20,7 +20,7 @@ describe Duktape::API::Thread do
     it "resumes Duktape execution" do
       ctx = Duktape::Context.new
       ctx.push_global_proc("test") do |ptr|
-      env = Duktape::Context.new ptr
+        env = Duktape::Context.new ptr
         state = env.suspend
         # do some blocking I/0 here...
         env.resume(state)

--- a/spec/duktape/api/type_spec.cr
+++ b/spec/duktape/api/type_spec.cr
@@ -213,7 +213,6 @@ describe Duktape::API::Type do
     end
   end
 
-
   describe "is_callable" do
     it "should return true if element is callable" do
       ctx = Duktape::Context.new

--- a/src/duktape/api/heap.cr
+++ b/src/duktape/api/heap.cr
@@ -20,7 +20,6 @@ module Duktape
   end
 
   def self.create_heap_default
-    LibDUK.create_heap(nil, nil, nil, nil, nil)
     create_heap do |udata, msg|
       str = String.new msg
       raise Duktape::InternalError.new str

--- a/src/duktape/builtin/console.cr
+++ b/src/duktape/builtin/console.cr
@@ -66,7 +66,7 @@ module Duktape
 
       private def prop_flags
         LibDUK::DefProp::Force.value |
-        LibDUK::DefProp::HaveValue.value
+          LibDUK::DefProp::HaveValue.value
       end
     end
   end

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR =  0
     MINOR = 12
-    TINY  =  0
+    TINY  =  1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
* Fix an unintended `Duktape` heap instantiation when
  creating a new `Duktape::Context`.
* Run `crystal tool format` on all source code.