### PR TITLE
Fix Type Inference Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.14.1 - May 13, 2018
+
+- Fix a type inference error on the Sandbox `@timeout` instance variable that occurs due to recent changes in Crystal master [#43]. Thanks @kostya!
+
 # v0.14.0 - Apr 30, 2018
 
 - Update Duktape to version `2.2.1`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.14.0
+    version: ~> 0.14.1
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.14.0
+version: 0.14.1
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/src/duktape/sandbox.cr
+++ b/src/duktape/sandbox.cr
@@ -7,7 +7,7 @@
 module Duktape
   class Sandbox < Context
     include Support::Time
-    getter timeout
+    getter timeout : Int32 | Int64 | Nil
 
     def initialize
       @ctx = Duktape.create_heap_default

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR =  0
     MINOR = 14
-    TINY  =  0
+    TINY  =  1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
* Crystal master has included type inference changes that
  introduce an error in the Sandbox `@timeout` instance
  variable.
* Write more explicit type annotations to resolve the issue.

SEE: https://github.com/jessedoyle/duktape.cr/issues/43