### PR TITLE
Version 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.16.0 - Apr, 21 2019
+
+- Update `ameba` to the current latest version of `v0.9.1`.
+- Build specs with all warnings enabled in Crystal >= `0.28.0`.
+- Fix a deprecation warning with Crystal `0.28.0` where integer division will return a float in future versions. Use `Int#//` to retain backwards compatibility.
+
 # v0.15.1 - Nov 7, 2018
 
 - Add [ameba](https://github.com/veelenga/ameba) as a development dependency for static analysis.

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ spec: all_spec
 all_spec: $(OUTPUT)/all_spec
 $(OUTPUT)/all_spec: $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(OUTPUT)
-	$(CRYSTAL_BIN) build -o $@ spec/all_spec.cr 2>/dev/null
+	$(CRYSTAL_BIN) build -o $@ spec/all_spec.cr --warnings all
 $(OUTPUT)/duktape: $(SOURCES)
 	@mkdir -p $(OUTPUT)
-	$(CRYSTAL_BIN) build -o $@ src/duktape.cr 2>/dev/null
+	$(CRYSTAL_BIN) build -o $@ src/duktape.cr --warnings all
 clean:
 	rm -rf $(OUTPUT)
 	rm -rf $(CURRENT)/.crystal

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.15.1
+    version: ~> 0.16.0
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.15.1
+version: 0.16.0
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>
@@ -10,6 +10,6 @@ scripts:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: 0.8.1
+    version: 0.9.1
 
 license: MIT

--- a/src/duktape/runtime.cr
+++ b/src/duktape/runtime.cr
@@ -328,11 +328,7 @@ module Duktape
     # :nodoc:
     private def stack_to_crystal(index : LibDUK::Index)
       case @context.get_type(index)
-      when :none
-        nil
-      when :undefined
-        nil
-      when :null
+      when :none, :undefined, :null
         nil
       when :boolean
         @context.get_boolean index

--- a/src/duktape/support/time.cr
+++ b/src/duktape/support/time.cr
@@ -16,12 +16,12 @@ module Duktape
     end
 
     def milli_to_sec_time_t(milli : Int32 | Int64)
-      LibC::TimeT.new milli.to_i64/1000
+      LibC::TimeT.new milli.to_i64 // 1000
     end
 
     def milli_to_micro_usec_t(milli : Int32 | Int64)
       milli = milli.to_i64
-      secs = milli / 1000
+      secs = milli // 1000
       LibC::SusecondsT.new((milli * 1000) - (secs * 1_000_000))
     end
 

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -15,8 +15,8 @@ module Duktape
 
   module VERSION
     MAJOR =  0
-    MINOR = 15
-    TINY  =  1
+    MINOR = 16
+    TINY  =  0
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
- Update for Crystal `0.28.0`. Fix deprecation warnings by
  using `Int#//` to return an integer instead of a float. This
  is a non-breaking change.
* Update `ameba` to the current latest version of `0.9.1`.
* Make all binaries with warnings enabled.