### PR TITLE
Release 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.17.0 - June 6, 2019
+
+- Update `ameba` to the latest current version (`0.10.0`) as previous versions no longer compile in CI.
+- Relax the restriction on `ameba` to pull in newer minor versions.
+
 # v0.16.0 - Apr, 21 2019
 
 - Update `ameba` to the current latest version of `v0.9.1`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.16.0
+    version: ~> 0.17.0
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.16.0
+version: 0.17.0
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>
@@ -10,6 +10,6 @@ scripts:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: 0.9.1
+    version: '~> 0.8'
 
 license: MIT


### PR DESCRIPTION
- Update `ameba` to the latest current version (`0.10.0`) as previous versions no longer compile in CI.
- Relax the restriction on `ameba` to pull in newer minor versions.