### PR TITLE
0.18.1 - Crystal 0.31.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.18.1 - Sept 24, 2019
+
+- Update for Crystal v0.31.0 support.
+- Fix test cases that were failing because Crystal's Spec library now executes `it` blocks at the end of the program (https://github.com/crystal-lang/crystal/pull/8125). Instead of manually destroying the Duktape head in specs, let the GC take care of it.
+- Update `ameba` to 0.10.1.
+
 # v0.18.0 - Sept 6, 2019
 
 - Update Duktape version to `2.4.0`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.18.0
+    version: ~> 0.18.1
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.18.0
+version: 0.18.1
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>
@@ -10,6 +10,6 @@ scripts:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: '~> 0.8'
+    version: '~> 0.10'
 
 license: MIT

--- a/spec/duktape/api/get_spec.cr
+++ b/spec/duktape/api/get_spec.cr
@@ -263,6 +263,4 @@ describe Duktape::API::Get do
       val.should eq(0_u32)
     end
   end
-
-  ctx.destroy_heap!
 end

--- a/spec/duktape/api/push_spec.cr
+++ b/spec/duktape/api/push_spec.cr
@@ -504,6 +504,4 @@ describe Duktape::API::Push do
       last_stack_type(ctx).should be_js_type(:undefined)
     end
   end
-
-  ctx.destroy_heap!
 end

--- a/spec/duktape/api/require_spec.cr
+++ b/spec/duktape/api/require_spec.cr
@@ -417,6 +417,4 @@ describe Duktape::API::Require do
       end
     end
   end
-
-  ctx.destroy_heap!
 end

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR =  0
     MINOR = 18
-    TINY  =  0
+    TINY  =  1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
- Update for Crystal v0.31.0 support.
- Fix test cases that were failing because Crystal's Spec library
  now executes `it` blocks at the end of the program
  (https://github.com/crystal-lang/crystal/pull/8125). Instead of
  manually destroying the Duktape heap in specs, let the GC take
  care of it.
- Update `ameba` to 0.10.1.