### PR TITLE
fix(runtime): function call with no arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.19.1 - March 3, 2020
+
+- **Bugfix**: Call function properties when using `Duktape::Runtime#call` with no function arguments. [PR 58](https://github.com/jessedoyle/duktape.cr/pull/58), [Issue 57](https://github.com/jessedoyle/duktape.cr/issues/57). Thanks @dinh for reporting!
+
 # v0.19.0 - Jan 17, 2020
 
 - Update Duktape version to `2.5.0`.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.19.0
+    version: ~> 0.19.1
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.19.0
+version: 0.19.1
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/spec/duktape/runtime_spec.cr
+++ b/spec/duktape/runtime_spec.cr
@@ -275,6 +275,26 @@ describe Duktape::Runtime do
         rt.ctx.get_top.should eq(0)
       end
     end
+
+    context "fix: https://github.com/jessedoyle/duktape.cr/issues/57", tags: "bugfix" do
+      it "calls functions when no arguments are provided" do
+        rt = Duktape::Runtime.new do |sbx|
+          sbx.eval! <<-JS
+            var called = false
+
+            function test() {
+              called = true;
+              return called;
+            }
+          JS
+        end
+
+        rt.call("test")
+        result = rt.call("called")
+
+        result.should be_true
+      end
+    end
   end
 
   describe "eval" do

--- a/spec/support/expectations/js_type_expectation.cr
+++ b/spec/support/expectations/js_type_expectation.cr
@@ -7,7 +7,7 @@ module Spec
     end
 
     def failure_message(actual_value)
-      "expected #{@target.inspect}\, got #{Duktape::TYPES[actual_value].inspect}"
+      "expected #{@target.inspect}, got #{Duktape::TYPES[actual_value].inspect}"
     end
 
     def negative_failure_message(actual_value)

--- a/src/duktape/runtime.cr
+++ b/src/duktape/runtime.cr
@@ -218,17 +218,14 @@ module Duktape
 
     # :nodoc:
     private def perform_call(args)
+      push_args(args)
+
+      obj_idx = -(args.size + 2)
       if args.size > 0
-        push_args args
-        # We want a reference to the last property that was
-        # successfully accessed via `get_prop`. Because we
-        # leave the last property name in the chain as a string
-        # , this should only depend on the number of arguments
-        # on the stack.
-        obj_idx = -(args.size + 2)
-        @context.call_prop obj_idx, args.size
+        @context.call_prop(obj_idx, args.size)
       else
-        @context.get_prop -2
+        @context.get_prop(obj_idx)
+        @context.call(0) if @context.is_callable(-1)
       end
     end
 

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -16,7 +16,7 @@ module Duktape
   module VERSION
     MAJOR =  0
     MINOR = 19
-    TINY  =  0
+    TINY  =  1
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
* We are currently reading the property when `Runtime#call` is called with no function arguments. In this case, we assume the property is a constant such as `Math.PI` and that the property must simply be read.
* When there are no arguments to `#call` we must coerce the property key on the stack (a string) to a function using `#get_prop`. This allows us to use the `#is_callable` API method to determine if we should execute a function to get the return value.
* Bump version to 0.19.1.

resolves: https://github.com/jessedoyle/duktape.cr/issues/57