### PR TITLE
feat(crystal-0.35.1): Update for Crystal 0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.21.0 - June 22, 2020
+
+* **breaking change**: Rename the `CRYSTAL_LOG_LEVEL` and `CRYSTAL_LOG_SOURCES` environment variables to `LOG_LEVEL` and `LOG_SOURCES` respectively to match changes in Crystal core.
+* Support Crystal >= 0.35.1.
+
 # v0.20.0 - April 13, 2020
 
 * **breaking change**: Remove the `Duktape::Logger` module and constants.

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ duktape: $(OUTPUT)/duktape
 libduktape:
 	$(MAKE) -C $(EXT) libduktape
 spec: all_spec
-	@CRYSTAL_LOG_LEVEL=$(CRYSTAL_LOG_LEVEL) CRYSTAL_LOG_SOURCES=$(CRYSTAL_LOG_SOURCES) $(OUTPUT)/all_spec
+	@LOG_LEVEL=$(CRYSTAL_LOG_LEVEL) LOG_SOURCES=$(CRYSTAL_LOG_SOURCES) $(OUTPUT)/all_spec
 all_spec: $(OUTPUT)/all_spec
 $(OUTPUT)/all_spec: $(SOURCES) $(SPEC_SOURCES)
 	@mkdir -p $(OUTPUT)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.20.0
+    version: ~> 0.21.0
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.20.0
+version: 0.21.0
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -15,7 +15,7 @@ module Duktape
 
   module VERSION
     MAJOR =  0
-    MINOR = 20
+    MINOR = 21
     TINY  =  0
     PRE   = nil
 


### PR DESCRIPTION
* Bump the version to 0.21.0.
* Update the `spec` target in the Makefile to include recent
  changes to environment variables for logging.
* Update CHANGELOG to reflect recent changes.