### PR TITLE
update to crystal version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# v0.22.0 - April 1, 2021
+# v1.0.0 - April 2, 2021
+
+* Specify a `crystal` constraint of `>= 0.35.1` for compatibility with Crystal 1.0.0. Thanks @Kanezoh!
 
 # v0.21.0 - June 22, 2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# v0.22.0 - April 1, 2021
+
 # v0.21.0 - June 22, 2020
 
 * **breaking change**: Rename the `CRYSTAL_LOG_LEVEL` and `CRYSTAL_LOG_SOURCES` environment variables to `LOG_LEVEL` and `LOG_SOURCES` respectively to match changes in Crystal core.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.21.0
+    version: ~> 0.22.0
 ```
 
 then execute:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ version: 1.0.0 # your project's version
 dependencies:
   duktape:
     github: jessedoyle/duktape.cr
-    version: ~> 0.22.0
+    version: ~> 1.0.0
 ```
 
 then execute:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.22.0
+version: 1.0.0
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: duktape
-version: 0.21.0
+version: 0.22.0
 
 authors:
   - Jesse Doyle <jdoyle@ualberta.ca>
@@ -11,5 +11,7 @@ development_dependencies:
   ameba:
     github: veelenga/ameba
     version: '~> 0.10'
+
+crystal: '>= 0.35.1'
 
 license: MIT

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -15,7 +15,7 @@ module Duktape
 
   module VERSION
     MAJOR =  0
-    MINOR = 21
+    MINOR = 22
     TINY  =  0
     PRE   = nil
 

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -14,8 +14,8 @@ module Duktape
   end
 
   module VERSION
-    MAJOR =  0
-    MINOR = 22
+    MAJOR =  1
+    MINOR = 0
     TINY  =  0
     PRE   = nil
 


### PR DESCRIPTION
Thank you for this shard!
This is what I wanted, but when I tried to install this shard on crystal version 1.0.0, crystal version is fixed under 1.0.0 and failed.
Here is the errors.
```
Unable to satisfy the following requirements:

- `crystal (< 1.0.0)` required by `duktape 0.21.0`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```

So, I specify crystal version as over 0.35.1 in shard.yml.

Thank you.