### PR TITLE
chore(ci): Move to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        crystal: [latest, nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Crystal
+        uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{ matrix.crystal }}
+      - name: Download source
+        uses: actions/checkout@v2
+      - name: Dependencies
+        run: shards install
+      - name: Build
+        run: make libduktape
+      - name: Run specs
+        run: make spec
+      - name: Check formatting
+        run: crystal tool format --check src spec
+      - name: Lint
+        run: bin/ameba

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: crystal
-before_install: make libduktape
-install:
-  - shards install
-script:
-  - make spec
-  - bin/ameba
-sudo: false
-email: false

--- a/src/duktape/version.cr
+++ b/src/duktape/version.cr
@@ -14,9 +14,9 @@ module Duktape
   end
 
   module VERSION
-    MAJOR =  1
+    MAJOR = 1
     MINOR = 0
-    TINY  =  0
+    TINY  = 0
     PRE   = nil
 
     STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."


### PR DESCRIPTION
* Migrate away from TravisCI to GitHub Actions as
  it's easier to setup, more common, faster and generally
  maintained better.