### PR TITLE
Change timeout semantics, support altering timeout per-eval

### DIFF
--- a/ext/duk_config.h
+++ b/ext/duk_config.h
@@ -3109,44 +3109,7 @@ typedef struct duk_hthread duk_context;
 /* __OVERRIDE_DEFINES__ */
 /* CUSTOM: timeout function */
 #define DUK_CR_USE_USER_DECLARE() \
-struct timeout_data \
-{ \
-	struct timeval start; \
-	struct timeval timeout; \
-}; \
-DUK_INTERNAL_DECL duk_bool_t duk_cr_timeout(void *udata) \
-{ \
-	if (udata) \
-	{ \
-		duk_ret_t rc; \
-		struct timeout_data data = *(struct timeout_data*) udata; \
-		struct timeval now; \
-		struct timeval diff; \
-		rc = gettimeofday(&now, NULL); \
-		if (rc != 0) \
-		{ \
-			return 1; \
-		} \
-		diff.tv_sec = now.tv_sec - data.start.tv_sec; \
-		diff.tv_usec = now.tv_usec - data.start.tv_usec; \
-		if (diff.tv_sec > data.timeout.tv_sec) \
-		{ \
-			return 1; \
-		} \
-		else if ((diff.tv_sec == data.timeout.tv_sec) && (diff.tv_usec > data.timeout.tv_usec)) \
-		{ \
-			return 1; \
-		} \
-		else \
-		{	\
-			return 0; \
-		}	\
-	} \
-	else \
-	{ \
-		return 0; \
-	} \
-}
+duk_bool_t duk_cr_timeout(void *udata);
 
 /*
  *  Conditional includes

--- a/spec/duktape/sandbox_spec.cr
+++ b/spec/duktape/sandbox_spec.cr
@@ -123,5 +123,31 @@ describe Duktape::Sandbox do
         JS
       end
     end
+
+    it "should respect an updated timeout when altered" do
+      sbx = Duktape::Sandbox.new(100)
+
+      t = Time.measure do
+        begin
+          sbx.eval! <<-JS
+              while (true) {}
+            JS
+        rescue ex
+        end
+      end
+      t.should be >= 100.milliseconds
+
+      sbx.timeout = 500.milliseconds
+
+      t = Time.measure do
+        begin
+          sbx.eval! <<-JS
+              while (true) {}
+            JS
+        rescue ex
+        end
+      end
+      t.should be >= 100.milliseconds
+    end
   end
 end

--- a/spec/duktape/sandbox_spec.cr
+++ b/spec/duktape/sandbox_spec.cr
@@ -106,6 +106,14 @@ describe Duktape::Sandbox do
     end
   end
 
+  describe "timeout=" do
+    it "should alter the timeout value" do
+      sbx = Duktape::Sandbox.new(200.milliseconds)
+      sbx.timeout = 500.milliseconds
+      sbx.timeout.should eq 500
+    end
+  end
+
   context "timeout during evaluation" do
     it "should raise a Duktape::RangeError on timeout" do
       sbx = Duktape::Sandbox.new(100)

--- a/src/duktape/runtime.cr
+++ b/src/duktape/runtime.cr
@@ -73,11 +73,11 @@ module Duktape
       reset_stack!
     end
 
-    def initialize(timeout : Int32 | Int64)
+    def initialize(timeout : Time::Span | Int32 | Int64)
       @context = Duktape::Sandbox.new timeout
     end
 
-    def initialize(timeout : Int32 | Int64, &block)
+    def initialize(timeout : Time::Span | Int32 | Int64, &block)
       @context = Duktape::Sandbox.new timeout
       yield @context
       # Remove all values from the stack left

--- a/src/duktape/runtime.cr
+++ b/src/duktape/runtime.cr
@@ -95,6 +95,13 @@ module Duktape
       reset_stack!
     end
 
+    def timeout=(timeout : Time::Span?)
+      ctx = @context
+      if ctx.is_a?(Duktape::Sandbox)
+        ctx.timeout = timeout
+      end
+    end
+
     # Call the named property with the supplied arguments,
     # returning the value of the called property.
     #

--- a/src/duktape/sandbox.cr
+++ b/src/duktape/sandbox.cr
@@ -5,14 +5,27 @@
 # This is free software. Please see LICENSE for details.
 
 module Duktape
+  class TimeoutData
+    property start : Time::Span
+    property timeout : Time::Span
+
+    def initialize(@start, @timeout)
+    end
+
+    def elapsed? : Bool
+      dt = Time.monotonic - @start
+      dt > timeout
+    end
+  end
+
   class Sandbox < Context
     include Support::Time
-    getter timeout : Int32 | Int64 | Nil
+
+    @timeout_data : TimeoutData?
 
     def initialize
       @ctx = Duktape.create_heap_default
       @heap_destroyed = false
-      @timeout = nil
       @should_gc = true
       builtin_functions
       secure!
@@ -21,7 +34,6 @@ module Duktape
     def initialize(context : LibDUK::Context)
       @ctx = context
       @heap_destroyed = false
-      @timeout = nil
       # NOTE: Don't automatically destroy the heap
       # on finalization when given a `LibDUK::Context`.
       @should_gc = false
@@ -29,16 +41,20 @@ module Duktape
       secure!
     end
 
-    def initialize(timeout : Int32 | Int64)
-      timeout = timeout.to_i64
-      if timeout < 100
+    def self.new(timeout : Int32 | Int64)
+      # NOTE(z64): backwards compatibility
+      Sandbox.new(timeout.milliseconds)
+    end
+
+    def initialize(timeout : Time::Span)
+      if timeout < 100.milliseconds
         raise ArgumentError.new "timeout must be > 100ms"
       else
-        udata = make_udata timeout
-        @ctx = Duktape.create_heap_udata udata
+        timeout_data = TimeoutData.new(Time::Span.zero, timeout)
+        @ctx = Duktape.create_heap_udata(timeout_data.unsafe_as(Pointer(Void)))
+        @timeout_data = timeout_data
       end
       @heap_destroyed = false
-      @timeout = timeout
       @should_gc = true
       builtin_functions
       secure!
@@ -48,16 +64,15 @@ module Duktape
       true
     end
 
-    def timeout?
-      timeout != nil
+    def timeout : Int32 | Int64 | Nil
+      # NOTE(z64): backwards compatibility
+      @timeout_data.try do |td|
+        td.timeout.total_milliseconds.to_i64
+      end
     end
 
-    private def make_udata(timeout : Int64)
-      start = current_time_nano
-      tv = timeout_timeval timeout
-      data = LibDUK::TimeoutData.new start: start, timeout: tv
-      slc = Slice(LibDUK::TimeoutData).new 1, data
-      slc.to_unsafe.as(Void*)
+    def timeout?
+      !@timeout_data.nil?
     end
 
     private def secure!
@@ -78,6 +93,39 @@ module Duktape
       push_string "Duktape"
       del_prop -2
       pop
+    end
+
+    # NOTE(z64): we monkey patch the following two eval_string methods from
+    # Context. this is so we can reset the start time within @timeout_data,
+    # which our timeout callback will read in duk_cr_timeout.
+
+    def eval_string(src : String)
+      flags = LibDUK::Compile.new(0_u32) |
+              LibDUK::Compile::Eval |
+              LibDUK::Compile::NoSource |
+              LibDUK::Compile::StrLen |
+              LibDUK::Compile::Safe |
+              LibDUK::Compile::NoFilename
+
+      if td = @timeout_data
+        td.start = Time.monotonic
+      end
+      LibDUK.eval_raw ctx, src, 0, flags
+    end
+
+    def eval_string_noresult(src : String)
+      flags = LibDUK::Compile.new(0_u32) |
+              LibDUK::Compile::Eval |
+              LibDUK::Compile::Safe |
+              LibDUK::Compile::NoSource |
+              LibDUK::Compile::StrLen |
+              LibDUK::Compile::NoResult |
+              LibDUK::Compile::NoFilename
+
+      if td = @timeout_data
+        td.start = Time.monotonic
+      end
+      LibDUK.eval_raw ctx, src, 0, flags
     end
   end
 end

--- a/src/duktape/sandbox.cr
+++ b/src/duktape/sandbox.cr
@@ -4,6 +4,17 @@
 #
 # This is free software. Please see LICENSE for details.
 
+# This is an exported function that is called by libduktape every so often by
+# an executing VM in order to check if a timeout has occurred. The pointer
+# passed is an instance of TimeoutData, which is also pointed to by a respective
+# Sandbox instance.
+fun duk_cr_timeout(ptr : Void*) : LibC::Int
+  return 0 if ptr.null?
+
+  timeout = ptr.unsafe_as(Duktape::TimeoutData)
+  timeout.elapsed? ? 1 : 0
+end
+
 module Duktape
   class TimeoutData
     property start : Time::Span

--- a/src/lib_duktape.cr
+++ b/src/lib_duktape.cr
@@ -164,11 +164,6 @@ lib LibDUK
     DontCare
   end
 
-  struct TimeoutData
-    start : LibC::Timeval
-    timeout : LibC::Timeval
-  end
-
   struct ThreadState
     data : UInt8[128]
   end


### PR DESCRIPTION
Hi Jesse! I have an interesting PR for you.

We have a particular use case wherein we do something like the following:

1. Create a `Sandbox` instance (via `Runtime`)
2. Load a *large* prelude of JS code - some libraries - into that runtime
3. Evaluate a small subset of scripts on that loaded runtime

This is a latency sensitive context, so we want to apply an execution timeout. However a few things are at odds with the current  implementation:

1. We want a realistic limit of something around 100ms. Most things we are running do not exceed this, if it does, its a problem.
2. Loading our JS prelude however can take upwards of 300ms
3. The sandbox timeout is measured from `Sandbox.new`, not `eval`!

So we were left with potentially having to create a new sandbox every time in order for the timeout to function well, but at the cost of awful latency.

I did some digging and found it easy enough to alter duktape to fit our use-case, which is namely allowing us to set a timeout that is measured per-`eval`, and allows us to take as much time we need loading our prelude into our `Runtime` singleton.

All that said, I leave these commits for your consideration. You will find my notes in code & commits. Please feel free to alter this branch as you see fit, we are using an internal fork for now, and I don't have much time to participate in code review.. but I'm happy to answer any questions or maybe I did something terrible :smile_cat: 

Hope all is well :heart: 