### PR TITLE
Fix ABI issues with Crystal 1.6

### DIFF
--- a/spec/duktape/api/coercion_spec.cr
+++ b/spec/duktape/api/coercion_spec.cr
@@ -37,7 +37,7 @@ describe Duktape::API::Coercion do
       JS
       tup = ctx.safe_to_lstring -1
 
-      tup.should be_a(Tuple(String, Int32))
+      tup.should be_a(Tuple(String, UInt64))
       tup[0].should eq("Error: toString error")
       tup[1].should eq(21)
     end
@@ -211,7 +211,7 @@ describe Duktape::API::Coercion do
       ctx << 123.456
       tup = ctx.to_lstring -1
 
-      tup.should be_a(Tuple(String, Int32))
+      tup.should be_a(Tuple(String, UInt64))
       tup[0].should eq("123.456")
       tup[1].should eq(7)
       last_stack_type(ctx).should be_js_type(:string)

--- a/src/lib_duktape.cr
+++ b/src/lib_duktape.cr
@@ -7,7 +7,7 @@
 @[Link(ldflags: "-L#{__DIR__}/.build/lib -L#{__DIR__}/.build/include -lduktape -lm")]
 lib LibDUK
   alias Context = Void*
-  alias Size = Int32
+  alias Size = LibC::SizeT
   alias Bool = UInt32
   alias Index = Int32
   alias Number = Float64

--- a/src/lib_duktape.cr
+++ b/src/lib_duktape.cr
@@ -197,6 +197,7 @@ lib LibDUK
     day : Number
     hours : Number
     minutes : Number
+    seconds : Number
     milliseconds : Number
     weekday : Number
   end


### PR DESCRIPTION
Crystal 1.6 introduced a change in the code generation for `out` values:

https://github.com/crystal-lang/crystal/pull/10952

It would appear that this uncovered a few incorrect FFI definitions in the duktape bindings, causing segfaults - you can see them by running the spec suite on `master`.

I am guessing that with the previous code generation in <1.6, sizes & alignments were being implicitly promoted, so it wasn't a problem.

I don't know exactly how much of the C API the spec suite hits (I assume a lot of it over 660 tests), so I can't say for certain if this is all of them... 

I opted to reference `LibC::SizeT` here, as the compiler should set the correct alias for the platform being built.